### PR TITLE
added one DA semseg paper notes and suggesting more changes

### DIFF
--- a/deep_learning/README.md
+++ b/deep_learning/README.md
@@ -2,21 +2,21 @@
 
 ### Semantic Segmentation
 
-| Paper | Link | Notes | Start Date | End Date |
-|:-----:|:----:|:-----:|:----------:|:--------:|
-| Gated-SCNN: Gated Shape CNNs for Semantic Segmentation (ICCV '19) | [Paper](http://openaccess.thecvf.com/content_ICCV_2019/html/Takikawa_Gated-SCNN_Gated_Shape_CNNs_for_Semantic_Segmentation_ICCV_2019_paper.html) | [HackMD](https://hackmd.io/tXDEyCEcTmqgaR75Gno0Mw) | 30/11/2019 | 05/12/2019 |
-| ENet: A Deep Neural Network Architecture for Real-Time Semantic Segmentation | [Paper](https://arxiv.org/abs/1606.02147) | [HackMD](https://hackmd.io/5jM_pajoSnS6LoZkdech8A) | 09/12/2019 | 20/12/2019 |
-| W-Net: A Deep Model for Fully Unsupervised Image Segmentation | [Paper](https://arxiv.org/abs/1711.08506) | [HackMD](https://hackmd.io/mNcCcyMFRuGLQg97qfTJaQ) | 20/12/2019 | 04/01/2020 |
-| Understanding Deep Learning Techniques for Image Segmentation | [Paper](https://arxiv.org/abs/1907.06119) | [HackMD](https://hackmd.io/RcL7gzVTTLCfJa1LGJGmZg) | 31/10/2019 | 08/12/2019 |
-| Recent progress in semantic image segmentation | [Paper](https://arxiv.org/ftp/arxiv/papers/1809/1809.10198.pdf) | [HackMD](https://hackmd.io/UpB9AC5CT0yTUmxGIsIArw) | 28/10/2019 | 07/12/2019 |
+| Paper| Notes | Start Date | End Date |
+|:-----:|:-----:|:----------:|:--------:|
+| [Gated-SCNN: Gated Shape CNNs for Semantic Segmentation](http://openaccess.thecvf.com/content_ICCV_2019/html/Takikawa_Gated-SCNN_Gated_Shape_CNNs_for_Semantic_Segmentation_ICCV_2019_paper.html) (ICCV '19) | [HackMD](https://hackmd.io/tXDEyCEcTmqgaR75Gno0Mw) | 30/11/2019 | 05/12/2019 |
+| [ENet: A Deep Neural Network Architecture for Real-Time Semantic Segmentation](https://arxiv.org/abs/1606.02147) | [HackMD](https://hackmd.io/5jM_pajoSnS6LoZkdech8A) | 09/12/2019 | 20/12/2019 |
+| [W-Net: A Deep Model for Fully Unsupervised Image Segmentation](https://arxiv.org/abs/1711.08506) | [HackMD](https://hackmd.io/mNcCcyMFRuGLQg97qfTJaQ) | 20/12/2019 | 04/01/2020 |
+| [Understanding Deep Learning Techniques for Image Segmentation](https://arxiv.org/abs/1907.06119) | [HackMD](https://hackmd.io/RcL7gzVTTLCfJa1LGJGmZg) | 31/10/2019 | 08/12/2019 |
+| [Recent progress in semantic image segmentation](https://arxiv.org/ftp/arxiv/papers/1809/1809.10198.pdf) | [HackMD](https://hackmd.io/UpB9AC5CT0yTUmxGIsIArw) | 28/10/2019 | 07/12/2019 |
 
 ### Active Learning
 
-| Paper | Link | Notes | Start Date | End Date |
-|:-----:|:----:|:-----:|:----------:|:--------:|
-| Variational Adversarial Active Learning (ICCV '19) | [Paper](https://arxiv.org/abs/1904.00370) | [HackMD](https://hackmd.io/CxZNGh6dS3m2axmP50iN8g) | 12/04/2020 | 16/04/2020 |
+| Paper | Notes | Start Date | End Date |
+|:-----:|:-----:|:----------:|:--------:|
+| [Variational Adversarial Active Learning](https://arxiv.org/abs/1904.00370) (ICCV '19) | [HackMD](https://hackmd.io/CxZNGh6dS3m2axmP50iN8g) | 12/04/2020 | 16/04/2020 |
 
 ### Domain Adaptation
-| Paper | Link | Notes | Start Date | End Date |
-|:-----:|:----:|:-----:|:----------:|:--------:|
-| Domain Adaptation for Structured Output via Discriminative Patch Representations (ICCV '19) | [Paper](https://arxiv.org/abs/1901.05427) | [HackMD](https://hackmd.io/Nh2sTmn1RpSeytghA6E2JQ) | 19/04/2020 | 21/04/2020 |
+| Paper | Notes | Start Date | End Date |
+|:-----:|:-----:|:----------:|:--------:|
+| [Domain Adaptation for Structured Output via Discriminative Patch Representations](https://arxiv.org/abs/1901.05427) (ICCV '19) | [HackMD](https://hackmd.io/Nh2sTmn1RpSeytghA6E2JQ) | 19/04/2020 | 21/04/2020 |

--- a/deep_learning/README.md
+++ b/deep_learning/README.md
@@ -15,3 +15,8 @@
 | Paper | Link | Notes | Start Date | End Date |
 |:-----:|:----:|:-----:|:----------:|:--------:|
 | Variational Adversarial Active Learning | [Paper](https://arxiv.org/abs/1904.00370) | [HackMD](https://hackmd.io/CxZNGh6dS3m2axmP50iN8g) | 12/04/2020 | 16/04/2020 |
+
+### Domain Adaptation
+| Paper | Link | Notes | Start Date | End Date |
+|:-----:|:----:|:-----:|:----------:|:--------:|
+| Domain Adaptation for Structured Output via Discriminative Patch Representations | [Paper](https://arxiv.org/abs/1901.05427) | [HackMD](https://hackmd.io/Nh2sTmn1RpSeytghA6E2JQ) | 19/04/2020 | 21/04/2020 |

--- a/deep_learning/README.md
+++ b/deep_learning/README.md
@@ -4,7 +4,7 @@
 
 | Paper | Link | Notes | Start Date | End Date |
 |:-----:|:----:|:-----:|:----------:|:--------:|
-| Gated-SCNN: Gated Shape CNNs for Semantic Segmentation | [Paper](http://openaccess.thecvf.com/content_ICCV_2019/html/Takikawa_Gated-SCNN_Gated_Shape_CNNs_for_Semantic_Segmentation_ICCV_2019_paper.html) | [HackMD](https://hackmd.io/tXDEyCEcTmqgaR75Gno0Mw) | 30/11/2019 | 05/12/2019 |
+| Gated-SCNN: Gated Shape CNNs for Semantic Segmentation (ICCV '19) | [Paper](http://openaccess.thecvf.com/content_ICCV_2019/html/Takikawa_Gated-SCNN_Gated_Shape_CNNs_for_Semantic_Segmentation_ICCV_2019_paper.html) | [HackMD](https://hackmd.io/tXDEyCEcTmqgaR75Gno0Mw) | 30/11/2019 | 05/12/2019 |
 | ENet: A Deep Neural Network Architecture for Real-Time Semantic Segmentation | [Paper](https://arxiv.org/abs/1606.02147) | [HackMD](https://hackmd.io/5jM_pajoSnS6LoZkdech8A) | 09/12/2019 | 20/12/2019 |
 | W-Net: A Deep Model for Fully Unsupervised Image Segmentation | [Paper](https://arxiv.org/abs/1711.08506) | [HackMD](https://hackmd.io/mNcCcyMFRuGLQg97qfTJaQ) | 20/12/2019 | 04/01/2020 |
 | Understanding Deep Learning Techniques for Image Segmentation | [Paper](https://arxiv.org/abs/1907.06119) | [HackMD](https://hackmd.io/RcL7gzVTTLCfJa1LGJGmZg) | 31/10/2019 | 08/12/2019 |
@@ -14,9 +14,9 @@
 
 | Paper | Link | Notes | Start Date | End Date |
 |:-----:|:----:|:-----:|:----------:|:--------:|
-| Variational Adversarial Active Learning | [Paper](https://arxiv.org/abs/1904.00370) | [HackMD](https://hackmd.io/CxZNGh6dS3m2axmP50iN8g) | 12/04/2020 | 16/04/2020 |
+| Variational Adversarial Active Learning (ICCV '19) | [Paper](https://arxiv.org/abs/1904.00370) | [HackMD](https://hackmd.io/CxZNGh6dS3m2axmP50iN8g) | 12/04/2020 | 16/04/2020 |
 
 ### Domain Adaptation
 | Paper | Link | Notes | Start Date | End Date |
 |:-----:|:----:|:-----:|:----------:|:--------:|
-| Domain Adaptation for Structured Output via Discriminative Patch Representations | [Paper](https://arxiv.org/abs/1901.05427) | [HackMD](https://hackmd.io/Nh2sTmn1RpSeytghA6E2JQ) | 19/04/2020 | 21/04/2020 |
+| Domain Adaptation for Structured Output via Discriminative Patch Representations (ICCV '19) | [Paper](https://arxiv.org/abs/1901.05427) | [HackMD](https://hackmd.io/Nh2sTmn1RpSeytghA6E2JQ) | 19/04/2020 | 21/04/2020 |

--- a/reinforcement_learning/README.md
+++ b/reinforcement_learning/README.md
@@ -2,7 +2,7 @@
 
 | Paper | Notes | Start Date | End Date |
 |:-----:|:-----:|:----------:|:--------:|
-| [Off-Policy Actor-Critic](https://arxiv.org/abs/1205.4839) | [HackMD](https://hackmd.io/@FtbpSED3RQWclbmbmkChEA/BkcB-xwvI/edit) | 06/05/2020 |     -    |
-| [Combining Physical Simulators and Object-Based Networks for Control](https://arxiv.org/pdf/1904.06580.pdf)| [HackMD](https://hackmd.io/@FtbpSED3RQWclbmbmkChEA/Sy6GPG9MB) | 06/05/2020 |  07/05/2020    |
+| [Off-Policy Actor-Critic](https://arxiv.org/abs/1205.4839) (ICML '12) | [HackMD](https://hackmd.io/@FtbpSED3RQWclbmbmkChEA/BkcB-xwvI/edit) | 06/05/2020 |     -    |
+| [Combining Physical Simulators and Object-Based Networks for Control](https://arxiv.org/pdf/1904.06580.pdf) (ICRA '19) | [HackMD](https://hackmd.io/@FtbpSED3RQWclbmbmkChEA/Sy6GPG9MB) | 06/05/2020 |  07/05/2020    |
 | [Learning Agile and Dynamic Motor Skills for Legged Robots](https://arxiv.org/abs/1901.08652)| [HackMD](https://hackmd.io/@FtbpSED3RQWclbmbmkChEA/ByzYzEhVS) | 06/05/2020 |  07/05/2020  |
-| [PAC-Bounds-for-Multi-armed-Bandit](https://link.springer.com/chapter/10.1007/3-540-45435-7_18) | [HackMD](https://hackmd.io/saK7DdqCRnyBfN3HykLhlA) | 05/04/2020 |     09/04/2020    |
+| [PAC-Bounds-for-Multi-armed-Bandit](https://link.springer.com/chapter/10.1007/3-540-45435-7_18) | [HackMD](https://hackmd.io/saK7DdqCRnyBfN3HykLhlA) | 05/04/2020 | 09/04/2020 |


### PR DESCRIPTION
Added paper notes for "Domain Adaptation for Structured Output via Discriminative Patch Representations". [Linking the notes here](https://hackmd.io/Nh2sTmn1RpSeytghA6E2JQ) for ease of access. 

While you go through the notes, I have another proposition. Let's mention the name of the conference where the paper is published alongside the paper name (only for tier-1 conferences like CVPR, NeurIPS, ICCV, ICML, ICLR, etc.). That will help people recognize the impact of these papers. It will be represented in short form (like ICLR '19), so it will be short and informative. Let me know whether this is a good idea or not (then I'll add more commits implementing that within this PR).